### PR TITLE
Changing default ports to be compatible with docker EE

### DIFF
--- a/docker-ee.conf
+++ b/docker-ee.conf
@@ -9,8 +9,8 @@ gestalt_admin_password=
 external_gateway_host=workloads.example.com
 external_gateway_protocol=http
 
-gestalt_ui_service_nodeport=31112
-gestalt_kong_service_nodeport=31113
+gestalt_ui_service_nodeport=33000
+gestalt_kong_service_nodeport=33001
 
 # ------------- Database Configuration --------------------------------------------
 # -- To provision an internal database, set provision_internal_database=Yes, then

--- a/docs/readme_docker_ee.md
+++ b/docs/readme_docker_ee.md
@@ -53,9 +53,9 @@ helm list
 
 **Note: The installer performs this step automatically by default.**  The behavior can be altered by modifying the `docker-ee.conf` configuration file.
 
-Gestalt Platform requires a Postgres database instance, which can be hosted in Kubernetes, or externally.  If hosting on Kubernetes, the database needs a persistent volume.  
+Gestalt Platform requires a Postgres database instance, which can be hosted in Kubernetes, or externally.  If hosting on Kubernetes, the database needs a persistent volume.
 
-**Hostpath PV Example:**  
+**Hostpath PV Example:**
 This example uses a hostpath volume to a local directory on a worker node.  Alternatively, NFS or another supported PV type may be used.
 ```
 kubectl apply -f - <<EOF
@@ -69,7 +69,7 @@ spec:
   capacity:
     storage: 100Mi
   hostPath:
-    path: /mnt/hostpath-volume-01
+    path: /tmp/hostpath-volume-01
     type: ""
   persistentVolumeReclaimPolicy: Delete
   storageClassName: hostpath
@@ -81,8 +81,8 @@ EOF
 ### Load balancer for Kubernetes Worker(s).
 
 A load balancer should be set up fronting the Kubernetes worker node(s), with two listeners configured:
- * One listener for Gestalt UI (default port 31112)
- * One listener for API Gateway (default port 31113)
+ * One listener for Gestalt UI (default port 33000)
+ * One listener for API Gateway (default port 33001)
 
 ## Install Gestalt Platform
 
@@ -101,8 +101,8 @@ Specifically, note the following configuration parameters:
 
 * `external_gateway_host` - This should be set to a DNS name for the external load balancer fronting the Kubernetes worker(s).
 * `external_gateway_protocol` - Set to 'http' or 'https' depending on the load balancer listener configuration.
-* `gestalt_ui_service_nodeport` - The nodeport to serve the Gestalt UI on (default 31112).
-* `gestalt_kong_service_nodeport` - The nodeport to serve the Kong API Gateway on (default 31113).
+* `gestalt_ui_service_nodeport` - The nodeport to serve the Gestalt UI on (default 33000).
+* `gestalt_kong_service_nodeport` - The nodeport to serve the Kong API Gateway on (default 33001).
 
 The Gestalt UI will be accessible from `${external_gateway_protocol}://${external_gateway_host}:${gestalt_ui_service_nodeport}`.
 

--- a/helpers/build-gestalt-config.sh
+++ b/helpers/build-gestalt-config.sh
@@ -26,8 +26,8 @@ fi
 # Defaults
 gestalt_ui_ingress_protocol=http    # Must be HTTP unless ingress supports https
 [ -z $external_gateway_protocol ]      && external_gateway_protocol=http
-[ -z $gestalt_ui_service_nodeport ]    && gestalt_ui_service_nodeport=31111
-[ -z $gestalt_kong_service_nodeport ]  && gestalt_kong_service_nodeport=31112
+[ -z $gestalt_ui_service_nodeport ]    && gestalt_ui_service_nodeport=33000
+[ -z $gestalt_kong_service_nodeport ]  && gestalt_kong_service_nodeport=33001
 
 # if [ ! -z "$PV_STORAGE_CLASS" ]; then
 #   PV_STORAGE_ANNOTATION="storageClassName: $PV_STORAGE_CLASS"


### PR DESCRIPTION
Hi GalacticFog team,

I looked at your docker-ee install instructions and I saw some issues I would like to fix:

 - Ports in the 30000-32767 range are reserved for Docker Swarm in Docker EE at the moment.
 - `/mnt` was causing issues when deploying the PV claim for Postgres.

Not sure where to put the changes so that they affect only Docker EE customers.